### PR TITLE
Pass context variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A Liquid tag plugin for Jekyll that allows remote includes from external sources
 ## Installation
 
 Add this line to your application's Gemfile:
+
 ```ruby
 group :jekyll_plugins do
     gem 'jekyll-remote-include', :github => 'netrics/jekyll-remote-include'
@@ -34,6 +35,14 @@ Use the tag as follows in your Jekyll pages, posts and collections:
 
 ```liquid
 {% remote_include https://raw.githubusercontent.com/jekyll/jekyll/master/README.markdown %}
+```
+
+or use with a liquid variable (eg. link from front matter):
+
+```liquid
+{% if page.my_variable %}
+  {% remote_include {{ page.my_variable }} %}
+{% endif %}
 ```
 
 ## Contributing

--- a/lib/jekyll-remote-include.rb
+++ b/lib/jekyll-remote-include.rb
@@ -19,18 +19,10 @@ module Jekyll
       begin
         # try
         URI.parse((@remote_include).strip)
-        local_url = 1
+        open("#{@remote_include}")
       rescue
         # catch
         URI.parse(context[@remote_include.strip].strip)
-        local_url = 2
-      ensure
-        # always
-      end
-
-      if local_url == 1
-        open("#{@remote_include}")
-      elsif local_url == 2
         open("#{context[@remote_include.strip]}")
       end
     end

--- a/lib/jekyll-remote-include.rb
+++ b/lib/jekyll-remote-include.rb
@@ -15,7 +15,24 @@ module Jekyll
     end
 
     def render(context)
-      open("#{@remote_include}")
+      local_url = nil
+      begin
+        # try
+        URI.parse((@remote_include).strip)
+        local_url = 1
+      rescue
+        # catch
+        URI.parse(context[@remote_include.strip].strip)
+        local_url = 2
+      ensure
+        # always
+      end
+
+      if local_url == 1
+        open("#{@remote_include}")
+      elsif local_url == 2
+        open("#{context[@remote_include.strip]}")
+      end
     end
 
   end


### PR DESCRIPTION
I added a begin / rescue block to test if path passed to tag is a path or a liquid variable from context.
I'm new to Ruby, so excuse the crude syntax :)
Tested on my [site](https://urishx.github.io) (repo: https://github.com/urishx/Jekyll-portfolio) in `_layouts/portfolio.html`, from the file `_plugins/jekyll-remote-include-param.rb`.